### PR TITLE
Add Option to Control Command Target for Offline Players

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ allprojects {
         compileOnly("org.jetbrains:annotations:23.0.0")
         compileOnly("org.jetbrains.kotlin:kotlin-stdlib:1.9.20")
 
-        compileOnly("me.clip:placeholderapi:2.11.2")
+        compileOnly("me.clip:placeholderapi:2.11.6")
         compileOnly("com.github.ben-manes.caffeine:caffeine:3.1.0")
     }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/EcoBitsPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/EcoBitsPlugin.kt
@@ -12,6 +12,11 @@ import org.bukkit.event.Listener
 class EcoBitsPlugin : EcoPlugin() {
     val serverID = configYml.getString("server-id")
 
+    //
+    val allowOfflinePlayersString = configYml.getString("allow-offline-players-in-commands")
+    val allowOfflinePlayers = allowOfflinePlayersString.toBoolean()
+    //
+
     init {
         instance = this
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGet.kt
@@ -5,21 +5,23 @@ import com.willfp.eco.core.command.impl.Subcommand
 import com.willfp.eco.util.StringUtils
 import com.willfp.eco.util.savedDisplayName
 import com.willfp.eco.util.toNiceString
+import com.willfp.ecobits.EcoBitsPlugin
 import com.willfp.ecobits.currencies.Currencies
 import com.willfp.ecobits.currencies.Currency
 import com.willfp.ecobits.currencies.getBalance
 import org.bukkit.Bukkit
+import org.bukkit.OfflinePlayer
 import org.bukkit.command.CommandSender
 import org.bukkit.util.StringUtil
 
 class CommandGet(
-    plugin: EcoPlugin,
-    private val currency: Currency? = null
+        plugin: EcoPlugin,
+        private val currency: Currency? = null
 ) : Subcommand(
-    plugin,
-    "get",
-    "ecobits.command.get",
-    false
+        plugin,
+        "get",
+        "ecobits.command.get",
+        false
 ) {
     override fun onExecute(sender: CommandSender, args: List<String>) {
         if (args.isEmpty()) {
@@ -27,10 +29,21 @@ class CommandGet(
             return
         }
 
-        @Suppress("DEPRECATION")
-        val player = Bukkit.getOfflinePlayer(args[0])
+        val allowOfflinePlayers = EcoBitsPlugin.instance.allowOfflinePlayers
+        val targetPlayer: OfflinePlayer? = if (allowOfflinePlayers) {
+            Bukkit.getOfflinePlayer(args[0])
+        } else {
+            Bukkit.getPlayer(args[0])
+        }
 
-        if (!player.hasPlayedBefore() && !player.isOnline) {
+        // Don't allow the usage on offline players
+        if (targetPlayer == null || (!allowOfflinePlayers && !targetPlayer.isOnline)) {
+            sender.sendMessage(plugin.langYml.getMessage("player-not-online"))
+            return
+        }
+
+        // Don't allow the usage on player that don't exist
+        if (!targetPlayer.hasPlayedBefore() && !targetPlayer.isOnline) {
             sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
             return
         }
@@ -50,10 +63,10 @@ class CommandGet(
         }
 
         sender.sendMessage(
-            plugin.langYml.getMessage("other-balance", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
-                .replace("%player%", player.savedDisplayName)
-                .replace("%amount%", player.getBalance(currency).toNiceString())
-                .replace("%currency%", currency.name)
+                plugin.langYml.getMessage("other-balance", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
+                        .replace("%player%", targetPlayer.savedDisplayName)
+                        .replace("%amount%", targetPlayer.getBalance(currency).toNiceString())
+                        .replace("%currency%", currency.name)
         )
     }
 
@@ -66,20 +79,18 @@ class CommandGet(
 
         if (args.size == 1) {
             StringUtil.copyPartialMatches(
-                args[0],
-                Bukkit.getOnlinePlayers().map { it.name },
-                completions
+                    args[0],
+                    Bukkit.getOnlinePlayers().map { it.name },
+                    completions
             )
         }
 
-        if (this.currency == null) {
-            if (args.size == 2) {
-                StringUtil.copyPartialMatches(
+        if (this.currency == null && args.size == 2) {
+            StringUtil.copyPartialMatches(
                     args[1],
                     Currencies.values().map { it.id },
                     completions
-                )
-            }
+            )
         }
 
         return completions

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGive.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGive.kt
@@ -5,21 +5,23 @@ import com.willfp.eco.core.command.impl.Subcommand
 import com.willfp.eco.util.StringUtils
 import com.willfp.eco.util.savedDisplayName
 import com.willfp.eco.util.toNiceString
+import com.willfp.ecobits.EcoBitsPlugin
 import com.willfp.ecobits.currencies.Currencies
 import com.willfp.ecobits.currencies.Currency
 import com.willfp.ecobits.currencies.adjustBalance
 import org.bukkit.Bukkit
+import org.bukkit.OfflinePlayer
 import org.bukkit.command.CommandSender
 import org.bukkit.util.StringUtil
 
 class CommandGive(
-    plugin: EcoPlugin,
-    private val currency: Currency? = null
+        plugin: EcoPlugin,
+        private val currency: Currency? = null
 ) : Subcommand(
-    plugin,
-    "give",
-    "ecobits.command.give",
-    false
+        plugin,
+        "give",
+        "ecobits.command.give",
+        false
 ) {
     private val argOffset = if (currency == null) 0 else -1
 
@@ -29,10 +31,21 @@ class CommandGive(
             return
         }
 
-        @Suppress("DEPRECATION")
-        val player = Bukkit.getOfflinePlayer(args[0])
+        val allowOfflinePlayers = EcoBitsPlugin.instance.allowOfflinePlayers
+        val targetPlayer: OfflinePlayer? = if (allowOfflinePlayers) {
+            Bukkit.getOfflinePlayer(args[0])
+        } else {
+            Bukkit.getPlayer(args[0])
+        }
 
-        if (!player.hasPlayedBefore() && !player.isOnline) {
+        // Don't allow the usage on offline players
+        if (targetPlayer == null || (!allowOfflinePlayers && !targetPlayer.isOnline)) {
+            sender.sendMessage(plugin.langYml.getMessage("player-not-online"))
+            return
+        }
+
+        // Don't allow the usage on player that don't exist
+        if (!targetPlayer.hasPlayedBefore() && !targetPlayer.isOnline) {
             sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
             return
         }
@@ -63,13 +76,13 @@ class CommandGive(
             return
         }
 
-        player.adjustBalance(currency, amount.toBigDecimal())
+        targetPlayer.adjustBalance(currency, amount.toBigDecimal())
 
         sender.sendMessage(
-            plugin.langYml.getMessage("gave-currency", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
-                .replace("%player%", player.savedDisplayName)
-                .replace("%amount%", amount.toNiceString())
-                .replace("%currency%", currency.name)
+                plugin.langYml.getMessage("gave-currency", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
+                        .replace("%player%", targetPlayer.savedDisplayName)
+                        .replace("%amount%", amount.toNiceString())
+                        .replace("%currency%", currency.name)
         )
     }
 
@@ -82,27 +95,25 @@ class CommandGive(
 
         if (args.size == 1) {
             StringUtil.copyPartialMatches(
-                args[0],
-                Bukkit.getOnlinePlayers().map { it.name },
-                completions
+                    args[0],
+                    Bukkit.getOnlinePlayers().map { it.name },
+                    completions
             )
         }
 
-        if (this.currency == null) {
-            if (args.size == 2) {
-                StringUtil.copyPartialMatches(
+        if (this.currency == null && args.size == 2) {
+            StringUtil.copyPartialMatches(
                     args[1],
                     Currencies.values().map { it.id },
                     completions
-                )
-            }
+            )
         }
 
         if (args.size == 3 + argOffset) {
             StringUtil.copyPartialMatches(
-                args[2 + argOffset],
-                arrayOf(1, 2, 3, 4, 5).map { it.toString() },
-                completions
+                    args[2 + argOffset],
+                    arrayOf(1, 2, 3, 4, 5).map { it.toString() },
+                    completions
             )
         }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGivesilent.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGivesilent.kt
@@ -5,21 +5,23 @@ import com.willfp.eco.core.command.impl.Subcommand
 import com.willfp.eco.util.StringUtils
 import com.willfp.eco.util.savedDisplayName
 import com.willfp.eco.util.toNiceString
+import com.willfp.ecobits.EcoBitsPlugin
 import com.willfp.ecobits.currencies.Currencies
 import com.willfp.ecobits.currencies.Currency
 import com.willfp.ecobits.currencies.adjustBalance
 import org.bukkit.Bukkit
+import org.bukkit.OfflinePlayer
 import org.bukkit.command.CommandSender
 import org.bukkit.util.StringUtil
 
 class CommandGivesilent(
-    plugin: EcoPlugin,
-    private val currency: Currency? = null
+        plugin: EcoPlugin,
+        private val currency: Currency? = null
 ) : Subcommand(
-    plugin,
-    "givesilent",
-    "ecobits.command.givesilent",
-    false
+        plugin,
+        "givesilent",
+        "ecobits.command.givesilent",
+        false
 ) {
     private val argOffset = if (currency == null) 0 else -1
 
@@ -28,10 +30,22 @@ class CommandGivesilent(
             return
         }
 
-        @Suppress("DEPRECATION")
-        val player = Bukkit.getOfflinePlayer(args[0])
+        val allowOfflinePlayers = EcoBitsPlugin.instance.allowOfflinePlayers
+        val targetPlayer: OfflinePlayer? = if (allowOfflinePlayers) {
+            Bukkit.getOfflinePlayer(args[0])
+        } else {
+            Bukkit.getPlayer(args[0])
+        }
 
-        if (!player.hasPlayedBefore() && !player.isOnline) {
+        // Don't allow the usage on offline players
+        if (targetPlayer == null || (!allowOfflinePlayers && !targetPlayer.isOnline)) {
+            sender.sendMessage(plugin.langYml.getMessage("player-not-online"))
+            return
+        }
+
+        // Don't allow the usage on player that don't exist
+        if (!targetPlayer.hasPlayedBefore() && !targetPlayer.isOnline) {
+            sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
             return
         }
 
@@ -49,7 +63,7 @@ class CommandGivesilent(
 
         val amount = args[2 + argOffset].toDoubleOrNull() ?: return
 
-        player.adjustBalance(currency, amount.toBigDecimal())
+        targetPlayer.adjustBalance(currency, amount.toBigDecimal())
     }
 
     override fun tabComplete(sender: CommandSender, args: List<String>): List<String> {
@@ -61,27 +75,25 @@ class CommandGivesilent(
 
         if (args.size == 1) {
             StringUtil.copyPartialMatches(
-                args[0],
-                Bukkit.getOnlinePlayers().map { it.name },
-                completions
+                    args[0],
+                    Bukkit.getOnlinePlayers().map { it.name },
+                    completions
             )
         }
 
-        if (this.currency == null) {
-            if (args.size == 2) {
-                StringUtil.copyPartialMatches(
+        if (this.currency == null && args.size == 2) {
+            StringUtil.copyPartialMatches(
                     args[1],
                     Currencies.values().map { it.id },
                     completions
-                )
-            }
+            )
         }
 
         if (args.size == 3 + argOffset) {
             StringUtil.copyPartialMatches(
-                args[2 + argOffset],
-                arrayOf(1, 2, 3, 4, 5).map { it.toString() },
-                completions
+                    args[2 + argOffset],
+                    arrayOf(1, 2, 3, 4, 5).map { it.toString() },
+                    completions
             )
         }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandPay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandPay.kt
@@ -5,26 +5,27 @@ import com.willfp.eco.core.command.impl.Subcommand
 import com.willfp.eco.util.StringUtils
 import com.willfp.eco.util.savedDisplayName
 import com.willfp.eco.util.toNiceString
+import com.willfp.ecobits.EcoBitsPlugin
 import com.willfp.ecobits.currencies.Currencies
 import com.willfp.ecobits.currencies.Currency
 import com.willfp.ecobits.currencies.adjustBalance
 import com.willfp.ecobits.currencies.getBalance
 import org.bukkit.Bukkit
+import org.bukkit.OfflinePlayer
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 import org.bukkit.util.StringUtil
-import java.math.BigDecimal
 import kotlin.math.ceil
 import kotlin.math.floor
 
 class CommandPay(
-    plugin: EcoPlugin,
-    private val currency: Currency? = null
+        plugin: EcoPlugin,
+        private val currency: Currency? = null
 ) : Subcommand(
-    plugin,
-    "pay",
-    "ecobits.command.pay",
-    true
+        plugin,
+        "pay",
+        "ecobits.command.pay",
+        true
 ) {
     private val argOffset = if (currency == null) 0 else -1
 
@@ -34,19 +35,31 @@ class CommandPay(
             return
         }
 
-        @Suppress("DEPRECATION")
-        val recipient = Bukkit.getOfflinePlayer(args[0])
+        val allowOfflinePlayers = EcoBitsPlugin.instance.allowOfflinePlayers
+        val recipient: OfflinePlayer? = if (allowOfflinePlayers) {
+            Bukkit.getOfflinePlayer(args[0])
+        } else {
+            Bukkit.getPlayer(args[0])
+        }
 
-        if ((!recipient.hasPlayedBefore() && !recipient.isOnline) || (recipient.uniqueId == player.uniqueId)) {
+        if (recipient == null || (!allowOfflinePlayers && !recipient.isOnline)) {
+            player.sendMessage(plugin.langYml.getMessage("player-not-online"))
+            return
+        }
+
+        if (!recipient.hasPlayedBefore() && !recipient.isOnline) {
             player.sendMessage(plugin.langYml.getMessage("invalid-player"))
             return
         }
 
-        if (this.currency == null) {
-            if (args.size < 2) {
-                player.sendMessage(plugin.langYml.getMessage("must-specify-currency"))
-                return
-            }
+        if (recipient.uniqueId == player.uniqueId) {
+            player.sendMessage(plugin.langYml.getMessage("invalid-player"))
+            return
+        }
+
+        if (this.currency == null && args.size < 2) {
+            player.sendMessage(plugin.langYml.getMessage("must-specify-currency"))
+            return
         }
 
         val currency = this.currency ?: Currencies.getByID(args[1].lowercase())
@@ -78,21 +91,19 @@ class CommandPay(
             return
         }
 
-        if (currency.max != null) {
-            if (recipient.getBalance(currency) + amount.toBigDecimal() > currency.max) {
-                player.sendMessage(plugin.langYml.getMessage("too-much"))
-                return
-            }
+        if (currency.max != null && recipient.getBalance(currency) + amount.toBigDecimal() > currency.max) {
+            player.sendMessage(plugin.langYml.getMessage("too-much"))
+            return
         }
 
         recipient.adjustBalance(currency, amount.toBigDecimal())
         player.adjustBalance(currency, -amount.toBigDecimal())
 
         player.sendMessage(
-            plugin.langYml.getMessage("paid-player", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
-                .replace("%player%", recipient.savedDisplayName)
-                .replace("%amount%", amount.toNiceString())
-                .replace("%currency%", currency.name)
+                plugin.langYml.getMessage("paid-player", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
+                        .replace("%player%", recipient.savedDisplayName)
+                        .replace("%amount%", amount.toNiceString())
+                        .replace("%currency%", currency.name)
         )
     }
 
@@ -105,27 +116,25 @@ class CommandPay(
 
         if (args.size == 1) {
             StringUtil.copyPartialMatches(
-                args[0],
-                Bukkit.getOnlinePlayers().map { it.name },
-                completions
+                    args[0],
+                    Bukkit.getOnlinePlayers().map { it.name },
+                    completions
             )
         }
 
-        if (this.currency == null) {
-            if (args.size == 2) {
-                StringUtil.copyPartialMatches(
+        if (this.currency == null && args.size == 2) {
+            StringUtil.copyPartialMatches(
                     args[1],
                     Currencies.values().filter { it.isPayable }.map { it.id },
                     completions
-                )
-            }
+            )
         }
 
         if (args.size == 3 + argOffset) {
             StringUtil.copyPartialMatches(
-                args[2 + argOffset],
-                arrayOf(1, 2, 3, 4, 5).map { it.toString() },
-                completions
+                    args[2 + argOffset],
+                    arrayOf(1, 2, 3, 4, 5).map { it.toString() },
+                    completions
             )
         }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandSet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandSet.kt
@@ -5,22 +5,23 @@ import com.willfp.eco.core.command.impl.Subcommand
 import com.willfp.eco.util.StringUtils
 import com.willfp.eco.util.savedDisplayName
 import com.willfp.eco.util.toNiceString
+import com.willfp.ecobits.EcoBitsPlugin
 import com.willfp.ecobits.currencies.Currencies
 import com.willfp.ecobits.currencies.Currency
-import com.willfp.ecobits.currencies.adjustBalance
 import com.willfp.ecobits.currencies.setBalance
 import org.bukkit.Bukkit
+import org.bukkit.OfflinePlayer
 import org.bukkit.command.CommandSender
 import org.bukkit.util.StringUtil
 
 class CommandSet(
-    plugin: EcoPlugin,
-    private val currency: Currency? = null
+        plugin: EcoPlugin,
+        private val currency: Currency? = null
 ) : Subcommand(
-    plugin,
-    "set",
-    "ecobits.command.set",
-    false
+        plugin,
+        "set",
+        "ecobits.command.set",
+        false
 ) {
     private val argOffset = if (currency == null) 0 else -1
 
@@ -30,10 +31,21 @@ class CommandSet(
             return
         }
 
-        @Suppress("DEPRECATION")
-        val player = Bukkit.getOfflinePlayer(args[0])
+        val allowOfflinePlayers = EcoBitsPlugin.instance.allowOfflinePlayers
+        val targetPlayer: OfflinePlayer? = if (allowOfflinePlayers) {
+            Bukkit.getOfflinePlayer(args[0])
+        } else {
+            Bukkit.getPlayer(args[0])
+        }
 
-        if (!player.hasPlayedBefore() && !player.isOnline) {
+        // Don't allow the usage on offline players
+        if (targetPlayer == null || (!allowOfflinePlayers && !targetPlayer.isOnline)) {
+            sender.sendMessage(plugin.langYml.getMessage("player-not-online"))
+            return
+        }
+
+        // Don't allow the usage on player that don't exist
+        if (!targetPlayer.hasPlayedBefore() && !targetPlayer.isOnline) {
             sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
             return
         }
@@ -64,13 +76,13 @@ class CommandSet(
             return
         }
 
-        player.setBalance(currency, amount.toBigDecimal())
+        targetPlayer.setBalance(currency, amount.toBigDecimal())
 
         sender.sendMessage(
-            plugin.langYml.getMessage("set-currency", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
-                .replace("%player%", player.savedDisplayName)
-                .replace("%amount%", amount.toNiceString())
-                .replace("%currency%", currency.name)
+                plugin.langYml.getMessage("set-currency", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
+                        .replace("%player%", targetPlayer.savedDisplayName)
+                        .replace("%amount%", amount.toNiceString())
+                        .replace("%currency%", currency.name)
         )
     }
 
@@ -78,32 +90,38 @@ class CommandSet(
         val completions = mutableListOf<String>()
 
         if (args.isEmpty()) {
-            return Bukkit.getOnlinePlayers().map { it.name }
+            return if (EcoBitsPlugin.instance.allowOfflinePlayers) {
+                Bukkit.getOfflinePlayers().mapNotNull { it.name }
+            } else {
+                Bukkit.getOnlinePlayers().map { it.name }
+            }
         }
 
         if (args.size == 1) {
             StringUtil.copyPartialMatches(
-                args[0],
-                Bukkit.getOnlinePlayers().map { it.name },
-                completions
+                    args[0],
+                    if (EcoBitsPlugin.instance.allowOfflinePlayers) {
+                        Bukkit.getOfflinePlayers().map { it.name }
+                    } else {
+                        Bukkit.getOnlinePlayers().map { it.name }
+                    },
+                    completions
             )
         }
 
-        if (this.currency == null) {
-            if (args.size == 2) {
-                StringUtil.copyPartialMatches(
+        if (this.currency == null && args.size == 2) {
+            StringUtil.copyPartialMatches(
                     args[1],
                     Currencies.values().map { it.id },
                     completions
-                )
-            }
+            )
         }
 
         if (args.size == 3 + argOffset) {
             StringUtil.copyPartialMatches(
-                args[2 + argOffset],
-                arrayOf(1, 2, 3, 4, 5).map { it.toString() },
-                completions
+                    args[2 + argOffset],
+                    arrayOf(1, 2, 3, 4, 5).map { it.toString() },
+                    completions
             )
         }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandTakesilent.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandTakesilent.kt
@@ -5,21 +5,23 @@ import com.willfp.eco.core.command.impl.Subcommand
 import com.willfp.eco.util.StringUtils
 import com.willfp.eco.util.savedDisplayName
 import com.willfp.eco.util.toNiceString
+import com.willfp.ecobits.EcoBitsPlugin
 import com.willfp.ecobits.currencies.Currencies
 import com.willfp.ecobits.currencies.Currency
 import com.willfp.ecobits.currencies.adjustBalance
 import org.bukkit.Bukkit
+import org.bukkit.OfflinePlayer
 import org.bukkit.command.CommandSender
 import org.bukkit.util.StringUtil
 
 class CommandTakesilent(
-    plugin: EcoPlugin,
-    private val currency: Currency? = null
+        plugin: EcoPlugin,
+        private val currency: Currency? = null
 ) : Subcommand(
-    plugin,
-    "takesilent",
-    "ecobits.command.takesilent",
-    false
+        plugin,
+        "takesilent",
+        "ecobits.command.takesilent",
+        false
 ) {
     private val argOffset = if (currency == null) 0 else -1
 
@@ -28,10 +30,22 @@ class CommandTakesilent(
             return
         }
 
-        @Suppress("DEPRECATION")
-        val player = Bukkit.getOfflinePlayer(args[0])
+        val allowOfflinePlayers = EcoBitsPlugin.instance.allowOfflinePlayers
+        val targetPlayer: OfflinePlayer? = if (allowOfflinePlayers) {
+            Bukkit.getOfflinePlayer(args[0])
+        } else {
+            Bukkit.getPlayer(args[0])
+        }
 
-        if (!player.hasPlayedBefore() && !player.isOnline) {
+        // Don't allow the usage on offline players
+        if (targetPlayer == null || (!allowOfflinePlayers && !targetPlayer.isOnline)) {
+            sender.sendMessage(plugin.langYml.getMessage("player-not-online"))
+            return
+        }
+
+        // Don't allow the usage on player that don't exist
+        if (!targetPlayer.hasPlayedBefore() && !targetPlayer.isOnline) {
+            sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
             return
         }
 
@@ -49,39 +63,45 @@ class CommandTakesilent(
 
         val amount = args[2 + argOffset].toDoubleOrNull() ?: return
 
-        player.adjustBalance(currency, -amount.toBigDecimal())
+        targetPlayer.adjustBalance(currency, -amount.toBigDecimal())
     }
 
     override fun tabComplete(sender: CommandSender, args: List<String>): List<String> {
         val completions = mutableListOf<String>()
 
         if (args.isEmpty()) {
-            return Bukkit.getOnlinePlayers().map { it.name }
+            return if (EcoBitsPlugin.instance.allowOfflinePlayers) {
+                Bukkit.getOfflinePlayers().mapNotNull { it.name }
+            } else {
+                Bukkit.getOnlinePlayers().map { it.name }
+            }
         }
 
         if (args.size == 1) {
             StringUtil.copyPartialMatches(
-                args[0],
-                Bukkit.getOnlinePlayers().map { it.name },
-                completions
+                    args[0],
+                    if (EcoBitsPlugin.instance.allowOfflinePlayers) {
+                        Bukkit.getOfflinePlayers().map { it.name }
+                    } else {
+                        Bukkit.getOnlinePlayers().map { it.name }
+                    },
+                    completions
             )
         }
 
-        if (this.currency == null) {
-            if (args.size == 2) {
-                StringUtil.copyPartialMatches(
+        if (this.currency == null && args.size == 2) {
+            StringUtil.copyPartialMatches(
                     args[1],
                     Currencies.values().map { it.id },
                     completions
-                )
-            }
+            )
         }
 
         if (args.size == 3 + argOffset) {
             StringUtil.copyPartialMatches(
-                args[2 + argOffset],
-                arrayOf(1, 2, 3, 4, 5).map { it.toString() },
-                completions
+                    args[2 + argOffset],
+                    arrayOf(1, 2, 3, 4, 5).map { it.toString() },
+                    completions
             )
         }
 

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -19,6 +19,11 @@
 
 server-id: "main" # Server ID for local currencies over MySQL/MongoDB.
 
+# allow-offline-players-in-commands: true
+# Determines if commands should be usable on offline players.
+# Note: Changes to this setting require a server restart to take effect.
+allow-offline-players-in-commands: true
+
 cache-expire-after: 300 # Leaderboard cache expire time in seconds.
 
 currencies:

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -20,6 +20,7 @@ messages:
   cannot-afford: "&cYou can't afford to do this!"
   paid-player: "&fYou paid %player%&r &a%amount%&r &f%currency%&f!"
   too-much: "&fYou can't pay %player%&r this many &f%currency%&f as they already have too many!"
+  player-not-online: "&fThe specified player is not &aonline&f!"
 top:
   name-empty: "&cEmpty"
   amount-empty: "&cEmpty"


### PR DESCRIPTION

This pull request introduces a new configuration option, allow-offline-players-in-commands, that allows server administrators to control whether currency-related commands can be executed on offline players.

- Added the configuration option allow-offline-players-in-commands to config.yml:
# allow-offline-players-in-commands: true
# Determines if commands should be usable on offline players.
# Note: Changes to this setting require a server restart to take effect.
allow-offline-players-in-commands: true

- Updated relevant commands (pay, give, take, etc.) to respect this configuration setting.
Added checks to prevent issuing currency to players who have never joined the server, improving command reliability.

On servers with a large number of players (e.g., 30,000 to 40,000 offline players), executing currency commands on offline players can lead to significant lag. Allowing administrators to control whether commands can target offline players helps mitigate performance issues and provides more flexibility for managing server resources.

For example, trying to give currency to offline players in such scenarios can cause severe lag: https://prnt.sc/q9LQ8fvvebB9