### PR TITLE
Make CommandGive work with player offline for a while

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGive.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGive.kt
@@ -33,13 +33,14 @@ class CommandGive(
             return
         }
 
-        @Suppress("DEPRECATION")
-        val player = Bukkit.getOfflinePlayer(args[0])
-
-        if (!player.hasPlayedBefore()) {
-            sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
-            return
-        }
+        val player = Bukkit.getPlayer(args[0])
+            ?: Bukkit.getOfflinePlayers().firstOrNull {
+                it.name.equals(args[0], ignoreCase = true)
+            }
+            ?: run {
+                sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
+                return
+            }
 
         if (this.currency == null) {
             if (args.size < 2) {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGive.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGive.kt
@@ -34,9 +34,7 @@ class CommandGive(
         }
 
         val player = Bukkit.getPlayer(args[0])
-            ?: Bukkit.getOfflinePlayers().firstOrNull {
-                it.name.equals(args[0], ignoreCase = true)
-            }
+            ?: Bukkit.getOfflinePlayerIfCached(args[0])
             ?: run {
                 sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
                 return


### PR DESCRIPTION
Changing logic of how the command get Offline players

Now check all Offline Players instead and compare it with the input.

It is less efficient yes but it's supposed to work and be more accurate. For an admin command I guess it's not that bad. 

This needs more testing but I'm opening it right now.