### PR TITLE
feat: Eco in Gradle Properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 
 group = "com.willfp"
 version = findProperty("version")!!
+val ecoVersion = findProperty("eco-version")
 
 base {
     archivesName.set(project.name)
@@ -39,7 +40,7 @@ allprojects {
     }
 
     dependencies {
-        compileOnly("com.willfp:eco:7.6.0")
+        compileOnly("com.willfp:eco:$ecoVersion")
         compileOnly("org.jetbrains:annotations:26.0.2")
         compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.3.0")
         compileOnly("com.github.ben-manes.caffeine:caffeine:3.2.3")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 version = 2.2.1
 plugin-name = EcoBits
+eco-version=7.6.0


### PR DESCRIPTION
Moves eco dependency version from hardcoded value in `build.gradle.kts` to `gradle.properties` as `eco-version`, following the same pattern as `libreforge-version`.