### PR TITLE
fix: allow giving currency to players on their first login

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGive.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecobits/commands/CommandGive.kt
@@ -36,7 +36,7 @@ class CommandGive(
         @Suppress("DEPRECATION")
         val player = Bukkit.getOfflinePlayer(args[0])
 
-        if (!player.hasPlayedBefore()) {
+        if (!player.hasPlayedBefore() && !player.isOnline) {
             sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
             return
         }


### PR DESCRIPTION
### Problem

When a player logs in for the **first time**, `OfflinePlayer#hasPlayedBefore()` returns `false` (they have no prior playerdata on disk yet). Because `CommandGive` gated on `!player.hasPlayedBefore()` alone, running `/eco give <player> <currency> <amount>` on a freshly-joined player who has never played before failed with the `invalid-player` message — even though they are online right now.

### Fix

Match the guard already used by the other commands (`CommandGet`, `CommandSet`, `CommandTake`, `CommandReset`, `CommandPay`, silent variants): treat the player as valid if they have played before **or** are currently online.

```kotlin
if (!player.hasPlayedBefore() && !player.isOnline) {
    sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
    return
}
```

Only `CommandGive` was missing the `&& !player.isOnline` condition; this brings it in line with the rest of the command set.